### PR TITLE
Fix tag qaulifier

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -20,15 +20,15 @@ var addCmd = &cobra.Command{
 	Use:     "add <item>",
 	Aliases: []string{"a"},
 	Example: `
-shelfit add @anime chainsawman .good .action !started
-shelfit add @manga dededede .favorite .drama +v1-v8 !finished`,
+shelfit add chainsawman !anime .good .action
+shelfit add dededede !manga .favorite .drama`,
 	Short: "Add an item to the shelf",
 	Long: `
 Add an item to the shelf
 
 There are inline flags to describe the item that you want to add:
 '!': Category (required)
-'#': Tag
+'.': Tag
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/shelfit/author.go
+++ b/shelfit/author.go
@@ -26,7 +26,7 @@ func (a *Author) Write(text string, note string) (*Content, error) {
 
 	for _, word := range strings.Split(text, " ") {
 		match := false
-		// Check for Category (quantified by "!")
+		// Check for Category (qualified by `!`)
 		re, _ = regexp.Compile(`^\![\p{L}\d_-]+`)
 		if re.MatchString(word) {
 			if !content.HasCategory {
@@ -37,8 +37,8 @@ func (a *Author) Write(text string, note string) (*Content, error) {
 			}
 			match = true
 		}
-		// Check for Tag (quantified by "#")
-		re, _ = regexp.Compile(`^\#[\p{L}\d_-]+`)
+		// Check for Tag (qualified by `.`)
+		re, _ = regexp.Compile(`^\.[\p{L}\d_-]+`)
 		if re.MatchString(word) {
 			content.HasTag = true
 			content.Tags = append(content.Tags, word[1:])


### PR DESCRIPTION
The previous tag qualifier `#` does not work on Powershell.
Changing back to the qualifier `.`